### PR TITLE
Update src/MongoDB.WindowsAzure.InstanceMaintainer/WinHostsUpdater.cs

### DIFF
--- a/src/MongoDB.WindowsAzure.InstanceMaintainer/WinHostsUpdater.cs
+++ b/src/MongoDB.WindowsAzure.InstanceMaintainer/WinHostsUpdater.cs
@@ -54,7 +54,7 @@ namespace MongoDB.WindowsAzure.InstanceMaintainer
                     return;
                 }
 
-                int timeInSeconds = 0;
+                int timeInSeconds = defaultTimeIntervalBetweenUpdates;
                 if (args.Length > 0)
                 {
                     if (!Int32.TryParse(args[0], out timeInSeconds))


### PR DESCRIPTION
Set default defaultTimeIntervalBetweenUpdates.  Fixes loop for when no arguments are passed in.
