### PR TITLE
Fix AZURE-78 and AZURE-79 + small items found.

### DIFF
--- a/Tools/BlobBackup/MongoDB.WindowsAzure.Tools.BlobBackup.csproj
+++ b/Tools/BlobBackup/MongoDB.WindowsAzure.Tools.BlobBackup.csproj
@@ -38,11 +38,7 @@
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\GlobalAssemblyInfo.cs">

--- a/Tools/BlobBackup/Program.cs
+++ b/Tools/BlobBackup/Program.cs
@@ -76,13 +76,9 @@ namespace MongoDB.WindowsAzure.Tools.BlobBackup
             }
             else
             {
-                try
+                if (!Uri.TryCreate(arg, UriKind.Absolute, out snapshotUri))
                 {
-                    snapshotUri = new Uri(arg);
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine("Invalid snapshot URL specified. Error {0}", e.Message);
+                    Console.WriteLine("ERROR: \"{0}\" is not a valid url", arg);
                     return false;
                 }
             }

--- a/src/MongoDB.WindowsAzure.Backup/BackupManager.cs
+++ b/src/MongoDB.WindowsAzure.Backup/BackupManager.cs
@@ -44,18 +44,18 @@ namespace MongoDB.WindowsAzure.Backup
             var client = storageAccount.CreateCloudBlobClient();
 
             // Load the container.
+            var container = client.GetContainerReference(Constants.BackupContainerName);
             try
             {
-                var container = client.GetContainerReference(Constants.BackupContainerName);
                 container.FetchAttributes();
-
-                // Collect all the blobs!
-                return container.ListBlobs().Select(item => ((CloudBlob) item)).Where(item => item.Name.EndsWith(".tar")).ToList();
             }
             catch (StorageClientException) // Container not found...
             {
                 return new List<CloudBlob>();
             }
+
+            // Collect all the blobs!
+            return container.ListBlobs().Select(item => ((CloudBlob) item)).Where(item => item.Name.EndsWith(".tar")).ToList();
         }
     }
 }

--- a/src/MongoDB.WindowsAzure.Backup/MongoDB.WindowsAzure.Backup.csproj
+++ b/src/MongoDB.WindowsAzure.Backup/MongoDB.WindowsAzure.Backup.csproj
@@ -42,12 +42,7 @@
     <Reference Include="Microsoft.WindowsFabric.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsFabric.Data.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="tar-cs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\tar-cs.dll</HintPath>

--- a/src/MongoDB.WindowsAzure.Common/MongoDB.WindowsAzure.Common.csproj
+++ b/src/MongoDB.WindowsAzure.Common/MongoDB.WindowsAzure.Common.csproj
@@ -57,12 +57,8 @@
       <HintPath>..\..\lib\mongocsharpdriver.1.4.2\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">

--- a/src/MongoDB.WindowsAzure.InstanceMaintainer/WinHostsUpdater.cs
+++ b/src/MongoDB.WindowsAzure.InstanceMaintainer/WinHostsUpdater.cs
@@ -80,7 +80,7 @@ namespace MongoDB.WindowsAzure.InstanceMaintainer
             }
             catch (Exception e)
             {
-                Trace.TraceError("Exception {0} and stack trace{1} and inner exception {2}", e.Message, e.StackTrace, e.InnerException);
+                Trace.TraceError("Exception {0}", e);
             }
             finally
             {
@@ -129,7 +129,5 @@ namespace MongoDB.WindowsAzure.InstanceMaintainer
             }
             return nodes;
         }
-
     }
-
 }

--- a/src/MongoDB.WindowsAzure.Manager/Controllers/SnapshotController.cs
+++ b/src/MongoDB.WindowsAzure.Manager/Controllers/SnapshotController.cs
@@ -44,9 +44,22 @@ namespace MongoDB.WindowsAzure.Manager.Controllers
         /// <returns></returns>
         public ActionResult New()
         {
-            var uri = SnapshotManager.MakeSnapshot(ServerStatus.Primary.Id, RoleSettings.StorageCredentials, RoleSettings.ReplicaSetName);
+            var primary = ServerStatus.Primary;
 
-            TempData["flashSuccess"] = "Snapshot created!";
+            if (primary == null)
+            {
+                TempData["flashError"] = "Primary unavailable.";
+            }
+            else
+            {
+                SnapshotManager.MakeSnapshot(
+                    primary.Id,
+                    RoleSettings.StorageCredentials,
+                    RoleSettings.ReplicaSetName);
+
+                TempData["flashSuccess"] = "Snapshot created!";
+            }
+
             return RedirectToAction("Index", "Dashboard");
         }
 

--- a/src/MongoDB.WindowsAzure.Manager/MongoDB.WindowsAzure.Manager.csproj
+++ b/src/MongoDB.WindowsAzure.Manager/MongoDB.WindowsAzure.Manager.csproj
@@ -53,8 +53,6 @@
     <Reference Include="MongoDB.Driver">
       <HintPath>..\..\lib\mongocsharpdriver.1.4.2\MongoDB.Driver.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.Entity" />
-    <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
     </Reference>
@@ -67,31 +65,16 @@
     <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web.DynamicData" />
-    <Reference Include="System.Web.Entity" />
-    <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Web.WebPages.Deployment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
-    <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\MongoDB.WindowsAzure.InstanceMaintainer\$(InstanceMaintainerPath)\MongoDB.WindowsAzure.InstanceMaintainer.exe.config">

--- a/src/MongoDB.WindowsAzure.MongoDBRole/DiagnosticsHelper.cs
+++ b/src/MongoDB.WindowsAzure.MongoDBRole/DiagnosticsHelper.cs
@@ -19,53 +19,160 @@
 namespace MongoDB.WindowsAzure.MongoDBRole
 {
 
-    using Microsoft.WindowsAzure.Diagnostics;
     using Microsoft.WindowsAzure.ServiceRuntime;
 
     using System;
     using System.Diagnostics;
     using System.IO;
+    using System.Security.Permissions;
+    using System.Text.RegularExpressions;
 
     internal class DiagnosticsHelper
     {
+        private static readonly string ExceptionMessageFormat =
+            "{0}" + Environment.NewLine + "{1}";
 
-        private static string messageFormat = "Instance-{0}:{1}";
+        private static readonly Regex regexEscapeMessage =
+            new Regex("[{}]", RegexOptions.Compiled);
+
+        private static readonly TraceSource traceSource = CreateTraceSource();
+
+        internal static IDisposable TraceMethod()
+        {
+            var stackFrame = new StackFrame(1);
+
+            return TraceMethod(stackFrame.GetMethod().Name);
+        }
+
+        internal static IDisposable TraceMethod(string methodName)
+        {
+            return new TraceStartStop(methodName);
+        }
+
+        internal static void TraceStart(string message)
+        {
+            traceSource.TraceEvent(TraceEventType.Start, 0, message);
+        }
+
+        internal static void TraceStop(string message)
+        {
+            traceSource.TraceEvent(TraceEventType.Stop, 0, message);
+        }
 
         internal static void TraceInformation(string message)
         {
-            try
-            {
-                Trace.TraceInformation(string.Format(
-                    messageFormat,
-                    RoleEnvironment.CurrentRoleInstance.Id,
-                    message));
-            }
-            catch { }
+            traceSource.TraceInformation(message);
+        }
+
+        internal static void TraceInformation(string format, params object[] args)
+        {
+            traceSource.TraceInformation(format, args);
         }
 
         internal static void TraceWarning(string message)
         {
-            try
-            {
-                Trace.TraceWarning(string.Format(
-                    messageFormat,
-                    RoleEnvironment.CurrentRoleInstance.Id,
-                    message));
-            }
-            catch { }
+            traceSource.TraceEvent(TraceEventType.Warning, 0, message);
+        }
+
+        internal static void TraceWarning(string format, params object[] args)
+        {
+            traceSource.TraceEvent(TraceEventType.Warning, 0, format, args);
         }
 
         internal static void TraceError(string message)
         {
-            try
-            {
-                Trace.TraceError(string.Format(
-                    messageFormat,
-                    RoleEnvironment.CurrentRoleInstance.Id,
-                    message));
-            }
-            catch { }
+            traceSource.TraceEvent(TraceEventType.Error, 0, message);
         }
 
+        internal static void TraceError(string format, params object[] args)
+        {
+            traceSource.TraceEvent(TraceEventType.Error, 0, format, args);
+        }
+
+        internal static void TraceInformationException(string message, Exception exception)
+        {
+            traceSource.TraceEvent(
+                TraceEventType.Information,
+                0,
+                EscapeMessage(message) + "{0}",
+                exception);
+        }
+
+        internal static void TraceWarningException(string message, Exception exception)
+        {
+            traceSource.TraceEvent(
+                TraceEventType.Warning,
+                0,
+                EscapeMessage(message) + "{0}",
+                exception);
+        }
+
+        internal static void TraceErrorException(string message, Exception exception)
+        {
+            traceSource.TraceEvent(
+                TraceEventType.Error,
+                0,
+                EscapeMessage(message) + "{0}",
+                exception);
+        }
+
+        private static TraceSource CreateTraceSource()
+        {
+            // Clone Trace but with an expanded name to include the current
+            // role instance id.
+            var name =
+                Path.GetFileName(Environment.GetCommandLineArgs()[0]) +
+                ": " +
+                RoleEnvironment.CurrentRoleInstance.Id;
+
+            var traceSource = new TraceSource(name, SourceLevels.All);
+
+            // Clear the default TraceSource listeners
+            traceSource.Listeners.Clear();
+
+            // Add the registered Trace listeners
+            traceSource.Listeners.AddRange(Trace.Listeners);
+
+            return traceSource;
+        }
+
+        private static string EscapeMessage(string message)
+        {
+            // Replace all instances of { and } with {{ and }} respectively.
+            return regexEscapeMessage.Replace(
+                message,
+                match => new string(match.Groups[0].Value[0], 2));
+        }
+
+        private static string GetAppName()
+        {
+            // Get the same value as
+            // System.Diagnostics.TraceInternal.AppName.
+            new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Assert();
+            return Path.GetFileName(Environment.GetCommandLineArgs()[0]);
+        }
+
+        private class TraceStartStop : IDisposable
+        {
+            private readonly string methodName;
+
+            public TraceStartStop(string methodName)
+            {
+                DiagnosticsHelper.TraceStart(methodName);
+
+                this.methodName = methodName;
+            }
+
+            #region IDisposable Members
+
+            public void Dispose()
+            {
+                DiagnosticsHelper.TraceStop(this.methodName);
+
+                GC.SuppressFinalize(this);
+            }
+
+            #endregion
+        }
     }
 }

--- a/src/MongoDB.WindowsAzure.MongoDBRole/MongoDB.WindowsAzure.MongoDBRole.csproj
+++ b/src/MongoDB.WindowsAzure.MongoDBRole/MongoDB.WindowsAzure.MongoDBRole.csproj
@@ -61,13 +61,8 @@
       <HintPath>..\..\lib\mongocsharpdriver.1.4.2\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.Services.Client" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
# High-level changes
- Fixed AZURE-79 Tracing: Trace/Diagnostic helpers shouldn't call String.Format or ToString()
  - Parameters now get passed through to TraceListeners
  - Implemented simple method enter/exit trace helper to standardize tracing
  - Implemented simple exception trace helper methods
- Fixed AZURE-78 Security: Eliminate catch(Exception) without rethrow
  - This is a relatively evil class of bugs that lead to undefined state when potentially serious errors get swallowed/masked (NullReferenceException; InvalidOperationException; ArgumentException; SEHException; memory corruption due to bit rot, etc.)
- Refactored config so that it all lives under Settings rather than being split between MongoDBRole, Utilities, and Settings
- Fixed a relatively evil class of bugs where invalid configuration settings would silently revert back to default configuration settings without any indication that the behavior was altered/undefined.
- Improved the RoleEntryPoint process model to not spend cycles spin-polling for status and to immediately terminate when MongoD exits or OnStop is called depending on the value of RecycleOnExit (as opposed to waiting for the next poll interval).
- Fixed a NullReferenceException crash in the Manager web application.
## Individual Changes:
### Tools/*BlobBackup
- *BlobBackup.csproj
  - Removed unused references (normally added by default to projects)
- Program.cs
  - Replaced catch (Exception) w/ Uri.TryCreate
### Src/*Backup/BackupManager
- BackupManager.cs
  - If a StorageClientException that occurred during ListBlobs were incorrectly being swallowed causing success and an empty set to be returned instead of an error.
- *Backup.csproj
  - Removed unused references (normally added by default to projects)
### Src/*Common
- ConnectionUtilities.cs
  - Replaced catch (Exception) w/ Roles.TryGetValue
    - Replaced ReplicaSetEnvironmentException (custom config exception) w/ standard ConfigurationErrorsException (eliminated a single use class-local class that wasn’t caught by any other code and wasn’t provide extra context)
- *Common.csproj
  - Removed unused references (normally added by default to projects)
### Src/*InstanceMaintainer
- *InstanceMaintainer.csproj
  - Removed unused references (normally added by default to projects)
- WinHostsUpdater.cs
  - Simplified log expression (message, stack, and inner exception are logged by default by exception.ToString()); standard formatting is also easier to parse, and trace listeners get access to the actual exception for mining and serialization purposes.
### Src/*Manager
- Controllers/SnapshotController.cs
  - Clicking on the backup link when no primary was available would result in a crash handler page (NullReferenceException) because ServerStatus.Primary would be null.  As mitigation, it will now show an error instead.  Down the road, a potentially better UX might be to allow backups from fresh secondaries, or disable the link if no available nodes exist with some sort of visual queue.
- Models/ReplicaSetStatus.cs
  - Replaced catch(Exception) w/ correct exception handlers
- *Manager.csproj
  - Removed unused references (normally added by default to projects)
### Src/*MongoDBRole
- DatabaseHelper.cs
  - IsReplicaSetInitialized: Removed a blank catch all; did some testing and the only exceptions that could legally be handled here could be MongoConnectionException and MongoCommandException.  However, this should never happen as the only code that calls IsReplicaSetInitialized calls EnsureMongoDIsListening before, which prevents both cases.  As such, any exceptions here actually are unhandled and should cause a crash because they are undefined.
  - EnsureMongodIsListening: Replaced catch(Exception) w/ correct exception handlers; as well as a note that retry back-off logic is needed at some point (retry and backoff are yin and yang, one without the other = DOS waiting to happen).
- DiagnosticsHelper.cs
  - Refactored this class to address AZURE-79;
    - Trace parameters now get passed through to the trace listener instead of being converted to strings.
    - Replaced Trace with a TraceSource that includes the RoleInstance name rather to eliminate the need to prepend it to every message (forcing premature string conversion).
    - Helpers have been added to standardize exception logging.
    - Added the TraceMethodDisposable class to enable automatic function wide using scopes for logging Begin/End sequences; note this also covers abnormal function exists such as exceptions.
    - Added the TraceMethod helper which automatically resolves the caller function name.
- *MongoDBRole.csproj
  - Removed unused references (normally added by default to projects)
- MongoDBRole.cs
  - Run: Eliminated the timer spin wait; the thread now never needs to wake up and immediately returns if MongoD  terminates.  If RecycleOnExit is specified, then Run will wait for OnStop to be called.  This eliminates unnecessary cycles due to the thread waking up, and enables shutdown to complete faster (instead of potentially delaying 15 seconds).
  - OnStart/OnStop: Calling base.OnStart/OnStop is not advised by MSFT as these functions do nothing other than immediately return.
  - RoleEnvironmentChanged: Simplified code by moving parsing/value extraction to Settings.cs
- Settings.cs
  - Maintainability: In several places different nomenclature was being used; standardized variable names to match their actual configuration value and to represent that they represented either the setting name or the setting value to make the code more self-documenting; ex. RecycleOnExit vs Recycle; LocalCacheDir vs LocalDataDir.
  - Split the static constructor up into individual configuration setting assessors methods; this eliminated duplicate similar code in MongoDBRole.cs:RoleEnvironmentChange by enabling RoleEnvironmentChange to call these individual setting assessors directly.  This change was motivated after examining how the multiple catch(Exception) blocks could be factored out.
  - Fixed a relatively serious bug around incorrect configuration settings; in the case where an admin misconfigures a setting into something that cannot be parsed, the node will revert to default settings rather than throwing an error.  These types of silent failures would leave the node incorrectly configured, leading to all sorts of unexpected scenarios that can go undetected.  Now if there is an unparsable setting, a standard ConfigurationErrorsException will be thrown for the invalid setting and value.
- Utilities.cs
  - Because configuration logic now lives in one place, several  methods were eliminated
  - Switched to the standard exception formatters
