### PR TITLE
Commits for AZURE-89/AZURE-92

### DIFF
--- a/Setup/solutionsetup.cmd
+++ b/Setup/solutionsetup.cmd
@@ -1,3 +1,6 @@
+@ECHO OFF
+SET CURDIR=%cd%
+cd %~dp0
 powershell.exe -Command "& {Set-ExecutionPolicy bypass}"
 powershell.exe .\solutionsetup.ps1
-
+cd %CURDIR%

--- a/Setup/solutionsetup.sh
+++ b/Setup/solutionsetup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Powershell wants to run from SETUPDIR
+SETUPDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $SETUPDIR
+
+powershell.exe -Command "& {Set-ExecutionPolicy bypass}"
+powershell.exe ./solutionsetup.ps1


### PR DESCRIPTION
AZURE-89: solutionsetup.cmd can't launch solutionsetup.ps1 in Git bash
- Add a solutionsetup.sh instead

AZURE-92: solutionsetup.cmd has to be run from the Setup directory
- Fix the cmd script to work from any directory
