### PR TITLE
GetLocalSlaveOkConnection call is incorrect

### DIFF
--- a/src/MongoDB.WindowsAzure.MongoDBRole/DatabaseHelper.cs
+++ b/src/MongoDB.WindowsAzure.MongoDBRole/DatabaseHelper.cs
@@ -130,7 +130,7 @@ namespace MongoDB.WindowsAzure.MongoDBRole
                     MongoServer conn;
                     if (RoleEnvironment.IsEmulated)
                     {
-                        conn = DatabaseHelper.GetLocalSlaveOkConnection(mongodPort + instanceId);
+                        conn = DatabaseHelper.GetLocalSlaveOkConnection(mongodPort);
                     }
                     else
                     {


### PR DESCRIPTION
The call to GetLocalSlaveOkConnection was adding the instance number to the mongodPort which resulted in incorrect behavior.  The port number is retrieved from each local webrole instance and doesn't need to be "adjusted" since it is already correct.

The original code was resulting in a large number of 'Unable to connect to server localhost:27022' errors since the instance 2 (running on port 27020) was trying to test for a connection to mongod on the wrong IP address.
